### PR TITLE
feat: add ghcr.io dual-registry push to docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,3 +1,12 @@
+# Registry Configuration:
+# This workflow pushes to both Docker Hub and GitHub Container Registry (ghcr.io).
+# To add or change registries:
+#   1. Add/remove -t flags in the "Build and push" step below
+#   2. Add/remove login steps for each registry
+#   3. Docker Hub: requires DOCKERHUB_USERNAME + DOCKERHUB_TOKEN secrets
+#   4. ghcr.io: uses GITHUB_TOKEN (auto-provided by GitHub Actions)
+#   5. Other registries (Quay, AWS ECR, etc.): add a login step + corresponding -t flag
+
 name: Build and Push Docker Images
 
 on:
@@ -119,6 +128,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push for each architecture
         run: |
           ADDON="${{ matrix.addon }}"
@@ -141,14 +157,16 @@ jobs:
               
               # Generate image name from template
               image=$(echo "$IMAGE_TEMPLATE" | sed "s/{arch}/${arch}/")
-              full_image="${{ env.REGISTRY }}/${image}:${VERSION}"
+              dh_image="${{ env.REGISTRY }}/${image}:${VERSION}"
+              ghcr_image="ghcr.io/${image}:${VERSION}"
               
-              echo "Building ${full_image} for ${platform} using ${base_image}"
+              echo "Building ${dh_image} + ${ghcr_image} for ${platform} using ${base_image}"
               
               docker buildx build \
                 --platform "$platform" \
                 --build-arg BUILD_FROM="$base_image" \
-                -t "$full_image" \
+                -t "$dh_image" \
+                -t "$ghcr_image" \
                 --push \
                 "$ADDON"
             fi


### PR DESCRIPTION
## Changes

- Added ghcr.io login step using `secrets.GITHUB_TOKEN`
- Build step now pushes to both Docker Hub and ghcr.io with two `-t` flags
- Added comment at top of workflow explaining how to add/change registries
- Addon config.yaml files are unchanged

## How it works

Each arch build now tags the image twice:
- `docker.io/sunfounder/{arch}-{slug}:{version}`
- `ghcr.io/sunfounder/{arch}-{slug}:{version}`

## To switch registries

Edit the workflow file:
1. Add/remove `-t` flags in the Build step
2. Add/remove login steps accordingly
3. See the comment block at the top of the workflow for details

## Test install

No install needed — this is a CI workflow change. To verify, push to a test branch or use workflow_dispatch after merge.