### PR TITLE
fix: pironman5-max Dockerfile use branch 1.3.6, remove deprecated pironman from CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,7 +17,6 @@ on:
     tags:
       - 'v*'
     paths:
-      - 'pironman/**'
       - 'pironman5/**'
       - 'pironman5-max/**'
       - 'pironman5-mini/**'
@@ -30,7 +29,6 @@ on:
       - main
       - master
     paths:
-      - 'pironman/**'
       - 'pironman5/**'
       - 'pironman5-max/**'
       - 'pironman5-mini/**'
@@ -58,15 +56,15 @@ jobs:
         run: |
           ADDONS=()
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            ADDONS=("pironman" "pironman5" "pironman5-max" "pironman5-mini" "pironman5-nas" "pironman5-ups" "pi-config-wizard")
+            ADDONS=("pironman5" "pironman5-max" "pironman5-mini" "pironman5-nas" "pironman5-ups" "pi-config-wizard")
           elif [ "${{ github.event_name }}" == "push" ] && [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            ADDONS=("pironman" "pironman5" "pironman5-max" "pironman5-mini" "pironman5-nas" "pironman5-ups" "pi-config-wizard")
+            ADDONS=("pironman5" "pironman5-max" "pironman5-mini" "pironman5-nas" "pironman5-ups" "pi-config-wizard")
           else
             DIFF_COMMIT="${{ github.event.before }}"
             if [ -z "$DIFF_COMMIT" ] || [ "$DIFF_COMMIT" == "0000000000000000000000000000000000000000" ]; then
               DIFF_COMMIT="HEAD~1"
             fi
-            for addon in pironman pironman5 pironman5-max pironman5-mini pironman5-nas pironman5-ups pi-config-wizard; do
+            for addon in pironman5 pironman5-max pironman5-mini pironman5-nas pironman5-ups pi-config-wizard; do
               if git diff --name-only "$DIFF_COMMIT" "${{ github.sha }}" | grep -q "^${addon}/"; then
                 ADDONS+=("$addon")
               fi

--- a/pironman5-max/Dockerfile
+++ b/pironman5-max/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get install git python3 python3-pip python3-setuptools -y
 RUN apt-get install -y libraspberrypi-bin
 
 # clone pironman 5
-RUN git clone -b max --depth=1 https://github.com/sunfounder/pironman5.git
+RUN git clone -b 1.3.6 --depth=1 https://github.com/sunfounder/pironman5.git
 
 # install pironman
 RUN cd /pironman5 && python3 install.py --skip-auto-start --skip-reboot --skip-dtoverlay --skip-modules --plain-text


### PR DESCRIPTION
## Changes

### pironman5-max/Dockerfile
- Change git clone branch from `max` to `1.3.6` for stable, versioned builds

### .github/workflows/docker-build.yml
- Remove the deprecated `pironman` addon from all trigger paths (push + pull_request)
- Remove `pironman` from the changed-addon detection arrays (workflow_dispatch, tag push, and diff-based detection)