### PR TITLE
fix: pass GITHUB_TOKEN as build arg for private repo git clone

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -165,6 +165,7 @@ jobs:
               docker buildx build \
                 --platform "$platform" \
                 --build-arg BUILD_FROM="$base_image" \
+                --build-arg GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}" \
                 -t "$dh_image" \
                 -t "$ghcr_image" \
                 --push \

--- a/pironman/Dockerfile
+++ b/pironman/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get install git python3 python3-pip python3-setuptools procps -y
 # add github branch ref to invalidating the docker cache.
 ADD https://api.github.com/repos/sunfounder/pironman/git/refs/heads/v2.0 version.json
 # clone pironman
-RUN git clone -b v2.0 --depth 1 https://github.com/sunfounder/pironman.git
+ARG GITHUB_TOKEN
+RUN git clone -b v2.0 --depth 1 https://${GITHUB_TOKEN}@github.com/sunfounder/pironman.git
 
 # install pironman
 RUN cd /pironman && python3 install.py --skip-config-txt --skip-auto-startup --skip-reboot

--- a/pironman5-max/Dockerfile
+++ b/pironman5-max/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get install git python3 python3-pip python3-setuptools -y
 RUN apt-get install -y libraspberrypi-bin
 
 # clone pironman 5
-RUN git clone -b max --depth=1 https://github.com/sunfounder/pironman5.git
+ARG GITHUB_TOKEN
+RUN git clone -b max --depth=1 https://${GITHUB_TOKEN}@github.com/sunfounder/pironman5.git
 
 # install pironman
 RUN cd /pironman5 && python3 install.py --skip-auto-start --skip-reboot --skip-dtoverlay --skip-modules --plain-text

--- a/pironman5-mini/Dockerfile
+++ b/pironman5-mini/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get install git python3 python3-pip python3-setuptools -y
 RUN apt-get install -y libraspberrypi-bin
 
 # clone pironman 5
-RUN git clone https://github.com/sunfounder/pironman5.git -b 1.2.12
+ARG GITHUB_TOKEN
+RUN git clone https://${GITHUB_TOKEN}@github.com/sunfounder/pironman5.git -b 1.2.12
 
 # install pironman
 RUN cd /pironman5 && python3 install.py --skip-auto-start --skip-reboot --skip-dtoverlay --skip-modules --plain-text

--- a/pironman5/Dockerfile
+++ b/pironman5/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get install git python3 python3-pip python3-setuptools -y
 RUN apt-get install -y libraspberrypi-bin
 
 # clone pironman 5
-RUN git clone https://github.com/sunfounder/pironman5.git -b 1.2.7
+ARG GITHUB_TOKEN
+RUN git clone https://${GITHUB_TOKEN}@github.com/sunfounder/pironman5.git -b 1.2.7
 
 # install pironman
 RUN cd /pironman5 && python3 install.py --skip-auto-start --skip-reboot --skip-dtoverlay --skip-modules --plain-text


### PR DESCRIPTION
## Summary

Docker build in CI fails because `git clone` inside Dockerfiles cannot access private repos (sunfounder/pironman, sunfounder/pironman5) without authentication.

## Changes

- Add `ARG GITHUB_TOKEN` in 4 Dockerfiles (pironman, pironman5, pironman5-mini, pironman5-max)
- Use `${GITHUB_TOKEN}@github.com` in clone URLs
- Pass `--build-arg GITHUB_TOKEN="${{ secrets.GITHUB_TOKEN }}"` in CI workflow

## Test

```bash
docker build --build-arg GITHUB_TOKEN=<PAT> --build-arg BUILD_FROM=homeassistant/armv7-base:latest pironman5-max/
```